### PR TITLE
Update to scrapper.py

### DIFF
--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -262,14 +262,19 @@ class GumroadScrapper:
         _traverse_tree(script["content"]["content_items"], Path("/"), parent_folder)
 
     # Pages - Recipe
-
+    # NOTE(PxINKY) If the purchase is a gift, A recite cant be generated, return empty
     def _scrap_recipe_page(self, url: str) -> str:
         soup = self._session.get_soup(url)
 
-        payment_info = soup.select_one(".main > div:nth-child(1) > div").string
-        price = payment_info.strip().split("\n")[0]  # \n$9.99\n— VISA *0000
+        payment_info_element = soup.select_one(".main > div:nth-child(1) > div")
+        if payment_info_element:
+            payment_info = payment_info_element.string
+            if payment_info:
+                price = payment_info.strip().split("\n")[0]  # \n$9.99\n— VISA *0000
+                return price
 
-        return price
+        self._logger.warning("Failed to extract payment info from %s", url)
+        return ""
 
     # File downloader
 

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -161,8 +161,8 @@ class GumroadScrapper:
         # additionally filenames can also contain invalid characters
         # Issue arises if the file_name is something like: 'File 1.0 / 2.0'
         # Simply sanitizing the filename before using it fixes this issue
-        product_creator = self.sanitize_filename(script["creator"]["name"].strip())
-        product_name = self.sanitize_filename(script["purchase"]["product_name"])
+        product_creator = self.sanitize_filename(script["creator"]["name"].strip(), self._slash_replacement)
+        product_name = self.sanitize_filename(script["purchase"]["product_name"], self._slash_replacement)
         
         if "/" in product_name:
             self._logger.warning("Product has '/' in its name! Replaced it with %r.", self._slash_replacement)
@@ -280,7 +280,7 @@ class GumroadScrapper:
         return ""
 
     # NOTE(PxINKY) Path sanitizer
-    def sanitize_filename(self, filename: str, replacement: str = "_") -> str:
+    def sanitize_filename(self, filename: str, replacement: str) -> str:
         invalid_chars = '<>:"/\\|?*'
         # Replace invalid characters and spaces with underscores
         sanitized_filename = ''.join(replacement if c in invalid_chars or c == ' ' else c for c in filename)

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -161,8 +161,8 @@ class GumroadScrapper:
         # additionally filenames can also contain invalid characters
         # Issue arises if the file_name is something like: 'File 1.0 / 2.0'
         # Simply sanitizing the filename before using it fixes this issue
-        product_creator = self.sanitize_filename(script["creator"]["name"].strip(), self._slash_replacement)
-        product_name = self.sanitize_filename(script["purchase"]["product_name"], self._slash_replacement)
+        product_creator = self.sanitize_filename(script["creator"]["name"].strip())
+        product_name = self.sanitize_filename(script["purchase"]["product_name"])
         
         if "/" in product_name:
             self._logger.warning("Product has '/' in its name! Replaced it with %r.", self._slash_replacement)
@@ -280,10 +280,10 @@ class GumroadScrapper:
         return ""
 
     # NOTE(PxINKY) Path sanitizer
-    def sanitize_filename(self, filename: str, replacement: str) -> str:
+    def sanitize_filename(self, filename: str) -> str:
         invalid_chars = '<>:"/\\|?*'
         # Replace invalid characters and spaces with underscores
-        sanitized_filename = ''.join(replacement if c in invalid_chars or c == ' ' else c for c in filename)
+        sanitized_filename = ''.join(self._slash_replacement if c in invalid_chars or c == ' ' else c for c in filename)
         return sanitized_filename
     
     # File downloader

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -234,8 +234,8 @@ class GumroadScrapper:
                 )
 
             for item in items:
-                # NOTE(PxINKY) Gumroad added a "file" type that is just a URL with a button, but this flags as a 0 byte file. So this will catch it
-                if item["type"] != "file" or item["file_size"] is None:
+                # NOTE(PxINKY) Gumroad added a "file" type that's embedded into the page resulting in no download_url
+                if item["type"] != "file" or item["download_url"] is None:
                     continue
 
                 file_id = item["id"]

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -159,6 +159,8 @@ class GumroadScrapper:
         product_creator = script["creator"]["name"].strip()
 
         product_name = script["purchase"]["product_name"]
+        # NOTE(PxINKY): This is for window machines, as windows does not allow the following special characters in directory names and some creators include them in names
+        product_name = re.sub(r'[<>:"/\\|?*]', '', product_name)
         if "/" in product_name:
             self._logger.warning("Product has '/' in its name! Replaced it with %r.", self._slash_replacement)
             product_name = product_name.replace("/", self._slash_replacement)

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -119,8 +119,15 @@ class GumroadScrapper:
             creator_username = re.search(
                 r"https:\/\/(.*)\.gumroad\.com\/", creator_profile_url
             ).group(1)
-
-            creator = result["product"]["creator"]["name"]
+            
+            # NOTE(PxINKY): Swapping to ID as a static variable, we can use a try-catch to reassign it if the creator's name does exist!
+            creator = result["product"]["creator_id"]
+            try:
+                creator = result["product"]["creator"]["name"]
+            except:
+                self._logger.warning(
+                    "Defaulting to creator ID (%r), creators name is missing", creator
+                    )
             product = result["product"]["name"]
 
             if creator_username not in creators:

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -234,7 +234,8 @@ class GumroadScrapper:
                 )
 
             for item in items:
-                if item["type"] != "file":
+                # NOTE(PxINKY) Gumroad added a "file" type that is just a URL with a button, but this flags as a 0 byte file. So this will catch it
+                if item["type"] != "file" or item["file_size"] is None:
                     continue
 
                 file_id = item["id"]


### PR DESCRIPTION
Added edge case if the creator has left the platform / no longer exists
Added edge case if download_url doesn't exist
Added edge case if product was gifted


Examples of this:
A deleted Gumroad account will leave the product/download available but `result["product"]["creator"]["name"]` would return `None`.

Gumroad added file embeds directly into the page, allowing creators to embed videos/images into the page, this result removes `download_url` from the item object.

If the user received the item using Gumroads gifting system they can't generate payment info.