### PR TITLE
Update scrapper.py

### DIFF
--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -66,6 +66,7 @@ class FilesCache:
         self._file_path = file_path
         self._storage: dict[str, set] = defaultdict(set)
         self._logger = logging.getLogger("cache")
+        self.load()  # Load cache on initialization
 
     def load(self) -> None:
         if not self._file_path.exists():
@@ -75,16 +76,16 @@ class FilesCache:
             for k, v in json.load(f).items():
                 self._storage[k] = set(v)
 
-        self._logger.debug("Cache has been loaded.")
+        self._logger.info("Cache has been loaded.")
 
     def save(self) -> None:
         with open(self._file_path, "w", encoding="utf-8") as f:
             json.dump(self._storage, f, default=list, indent=2)
 
-        self._logger.debug("Cache has been saved.")
+        self._logger.info("Cache has been saved.")
 
     def is_cached(self, product_id: str, file_id: str) -> bool:
-        return file_id in self._storage.get(product_id, [])
+        return file_id in self._storage.get(product_id, []) 
 
     def cache(self, product_id: str, file_id: str) -> None:
         self._storage[product_id].add(file_id)
@@ -109,16 +110,34 @@ class GumroadScrapper:
 
     # Pages - Library
 
-    def scrape_library(self, creators: set[str]) -> None:
+    def scrape_library(self, creators: set[str] = ".") -> None:
         soup = self._session.get_soup(self._session.base_url + "/library")
         self._detect_redirect(soup)
 
         script = _load_json_data(soup, "LibraryPage")
+
         for result in script["results"]:
-            creator_profile_url = result["product"]["creator"]["profile_url"]
-            creator_username = re.search(
-                r"https:\/\/(.*)\.gumroad\.com\/", creator_profile_url
-            ).group(1)
+            # NOTE(PxINKY) Seems on very very rare occasions the profile can be missing the 'creator' object 
+            # Gumroad has dissallowed the username "none" from being picked, so it makes a good choice here
+            creator_profile_url = "none"
+            try:
+                creator_profile_url = result["product"]["creator"]["profile_url"]
+            except:
+                self._logger.warning(
+                    "Could not find creator for %r", result["product"]["name"]
+                    )
+                
+            
+            creator_username = "none" 
+            # Gumroad added "?recommended_by=library" to the end of 'profile_url'
+            try:
+                creator_username = re.search(
+                    r"https:\/\/(.*)\.gumroad\.com\?recommended_by=library", creator_profile_url
+                ).group(1)
+            except:
+                self._logger.warning(
+                    "Could not find creator in profile_url"
+                    )
             
             # NOTE(PxINKY): Swapping to ID as a static variable, we can use a try-catch to reassign it if the creator's name does exist!
             creator = result["product"]["creator_id"]
@@ -129,8 +148,8 @@ class GumroadScrapper:
                     "Defaulting to creator ID (%r), creators name is missing", creator
                     )
             product = result["product"]["name"]
-
-            if creator_username not in creators:
+            # Since creators needs a default value, we make sure it is either changed or not.
+            if creator_username not in creators and creators != ".":
                 self._logger.debug("Skipping %r product of %r.", product, creator)
                 continue
 
@@ -141,8 +160,9 @@ class GumroadScrapper:
                 continue
 
             updated_at = parse_date(result["product"]["updated_at"]).date()
-            self.scrap_product_page(result["purchase"]["download_url"], updated_at)
+            self.scrap_product_page(result["purchase"]["download_url"], updated_at) 
 
+    
     # Pages - Product content
 
     def scrap_product_page(self, url: str, uploaded_at: date | None = None) -> None:
@@ -159,14 +179,9 @@ class GumroadScrapper:
         # NOTE(PxINKY) Gumroad filters the username (Page URL / Profile Link username) on creation/edit
         # but not the "name" (["creator"]["name"]) from having invalid characters
         # additionally filenames can also contain invalid characters
-        # Issue arises if the file_name is something like: 'File 1.0 / 2.0'
         # Simply sanitizing the filename before using it fixes this issue
         product_creator = self.sanitize_filename(script["creator"]["name"].strip())
         product_name = self.sanitize_filename(script["purchase"]["product_name"])
-        
-        if "/" in product_name:
-            self._logger.warning("Product has '/' in its name! Replaced it with %r.", self._slash_replacement)
-            product_name = product_name.replace("/", self._slash_replacement)
 
         recipe_link = f"{self._session.base_url}/purchases/{script['purchase']['id']}/receipt"
         price = self._scrap_recipe_page(recipe_link)
@@ -219,6 +234,9 @@ class GumroadScrapper:
         file_type = tree_elements[0].select_one("li:nth-child(1)").string.strip().lower()
         return file_type in _ARCHIVES_EXT
 
+    
+    # Item - scanner / Downloader  
+    
     def _download_content(self, script: dict, parent_folder: Path) -> None:
         product_id = script["purchase"]["product_id"]
 
@@ -244,7 +262,10 @@ class GumroadScrapper:
                     continue
 
                 file_id = item["id"]
-                file_name = item["file_name"]
+                # Sanitize the file name
+                # Issue arises if the file_name is something like: 'File 1.0 / 2.0'
+                # Sanitizing the file_name should prevent this
+                file_name = self.sanitize_filename(item["file_name"]) 
                 file_type = item["extension"].lower()
                 file_url = self._session.base_url + item["download_url"]
 
@@ -264,29 +285,33 @@ class GumroadScrapper:
 
         _traverse_tree(script["content"]["content_items"], Path("/"), parent_folder)
 
+
     # Pages - Recipe
-    # NOTE(PxINKY) If the purchase is a gift, A recite cant be generated, return empty
+   
     def _scrap_recipe_page(self, url: str) -> str:
         soup = self._session.get_soup(url)
-
         payment_info_element = soup.select_one(".main > div:nth-child(1) > div")
         if payment_info_element:
             payment_info = payment_info_element.string
             if payment_info:
                 price = payment_info.strip().split("\n")[0]  # \n$9.99\n— VISA *0000
                 return price
-
+        # NOTE(PxINKY) If the purchase is a gift, A recite cant be generated, return empty
         self._logger.warning("Failed to extract payment info from %s", url)
         return ""
 
-    # NOTE(PxINKY) Path sanitizer
+    
+    # (PxINKY) - File name sanitizer
+    
     def sanitize_filename(self, filename: str) -> str:
-        invalid_chars = '<>:"/\\|?*'
+        invalid_chars = r'<>:"/\|?*'
         # Replace invalid characters and spaces with underscores
-        sanitized_filename = ''.join(self._slash_replacement if c in invalid_chars or c == ' ' else c for c in filename)
+        sanitized_filename = ''.join(self._slash_replacement if c in invalid_chars else c for c in filename)
         return sanitized_filename
+
     
     # File downloader
+    
     def _fancy_download_file(
         self,
         product_id: str,
@@ -300,7 +325,6 @@ class GumroadScrapper:
         transient: bool,
     ) -> None:
         tree_file_path = tree_path / file_path.name
-
         if self._files_cache.is_cached(product_id, file_id):
             self._logger.debug("'%s' is already downloaded! Skipping.", tree_file_path)
             return
@@ -333,6 +357,9 @@ class GumroadScrapper:
                         file.write(chunk)
 
         self._files_cache.cache(product_id, file_id)
+        self._files_cache.save() # save after each sucsessful download
+        self._logger.info("Downloaded '%s' to '%s'", tree_file_path, file_path)
+
 
     # Utils
 


### PR DESCRIPTION
Included changes from update (#9)


=== Cache ===
Made cache load on initialization, in turn allows the script to start right where it left off, reducing the redownloading of already archived files

Made cache save after each successful download

TODO: Make the logger show that its currently scanning through cache so user knows the script is still running

=== scrape library ===
Fixed edge case that result['product']['creator'] would return NoneType. Done by setting creator default to "none" and try/catch assigning it to the value

Fixed creator_username = re.search() in scrape_library as Gumroad updated their creator links to include "?recommended_by=library".

Removed redundant code that sanitized names unessassarily

=== Other ===
Fixed an issue where using gumroad_util's "scrapper.scrapelibrary()" without inserting a creator would cause the script to crash.

Added some extra logging output to _fancy_download

changed logging around the cache (.warning -> .log)



I did this all on a windows machine, so if it is different on other distros/OS please do give it a test before pushing the update ^-^