### PR TITLE
fix: Add files cache to scraper call, fix regex, add dl_all flag

### DIFF
--- a/gumroad_utils/cli.py
+++ b/gumroad_utils/cli.py
@@ -63,5 +63,11 @@ def get_cli_arg_parser() -> ArgumentParser:
         help="An output directory (default: current directory).",
         default=Path.cwd(),
     )
+    parser.add_argument(
+        "-a",
+        "--dl-all",
+        action="store_true",
+        help="Download all creators (default: false)"
+    )
 
     return parser

--- a/gumroad_utils/run.py
+++ b/gumroad_utils/run.py
@@ -49,6 +49,7 @@ def main() -> None:
     files_cache = FilesCache(cast("Path", args.config).parent / "gumroad.cache")
     scrapper = GumroadScrapper(
         session,
+        files_cache,
         root_folder=args.output,
         product_folder_tmpl=config["scrapper"]["product_folder_tmpl"],
         slash_replacement=config["scrapper"]["slash_replacement"],

--- a/gumroad_utils/run.py
+++ b/gumroad_utils/run.py
@@ -81,7 +81,7 @@ def main() -> None:
                 scrapper.scrap_product_page(link)
                 gc.collect()
         else:
-            scrapper.scrape_library(creators)
+            scrapper.scrape_library(creators, dl_all=args.dl_all)
 
     except Exception:
         logging.getLogger().exception("")

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -109,7 +109,11 @@ class GumroadScrapper:
 
     # Pages - Library
 
-    def scrape_library(self, creators: set[str]) -> None:
+    def scrape_library(
+            self,
+            creators: set[str],
+            dl_all: bool=False
+        ) -> None:
         soup = self._session.get_soup(self._session.base_url + "/library")
         self._detect_redirect(soup)
 
@@ -130,7 +134,7 @@ class GumroadScrapper:
                     )
             product = result["product"]["name"]
 
-            if creator_username not in creators:
+            if not dl_all and creator_username not in creators:
                 self._logger.debug("Skipping %r product of %r.", product, creator)
                 continue
 

--- a/gumroad_utils/scrapper.py
+++ b/gumroad_utils/scrapper.py
@@ -117,7 +117,7 @@ class GumroadScrapper:
         for result in script["results"]:
             creator_profile_url = result["product"]["creator"]["profile_url"]
             creator_username = re.search(
-                r"https:\/\/(.*)\.gumroad\.com\/", creator_profile_url
+                r"https:\/\/(.*)\.gumroad\.com", creator_profile_url
             ).group(1)
             
             # NOTE(PxINKY): Swapping to ID as a static variable, we can use a try-catch to reassign it if the creator's name does exist!


### PR DESCRIPTION
* Fixes an issue introduced in d1885e2 that causes program to fail due to improper implementation of FilesCache
* Fixes an issue where a regular expression is expecting a trailing slash, causing regex to fail.
* Adds a flag to download everything, as the default seems to imply that everything is downloaded when it is not. The creators assignment if there is no argument for creators assigns an empty set. Given that scrape_library checks to see if the creator is in this set, this causes no creators to be downloaded by default.